### PR TITLE
Index adapter `uploadFiles` method

### DIFF
--- a/lib/models/config.js
+++ b/lib/models/config.js
@@ -49,6 +49,7 @@ module.exports = CoreObject.extend({
       'manifestPrefix': this.project.name(),
       'store.manifestSize': 10,
       'store.type': 'redis',
+      'indexFiles': null,
       'tagging': 'sha'
     };
   },

--- a/lib/tasks/deploy-index.js
+++ b/lib/tasks/deploy-index.js
@@ -41,10 +41,17 @@ module.exports = Task.extend({
       ui: ui
     });
 
-    return readFile('dist/index.html')
-      .then(function(fileContent) {
-        ui.writeLine(chalk.blue('\nTrying to upload `dist/index.html`...\n'));
-        return deploy.upload(fileContent);
-      });
+    var indexFiles = config.get('indexFiles');
+
+    if(indexFiles) {
+      ui.writeLine(chalk.blue('\nUploading '+indexFiles.length+' files from `dist/`...\n'));
+      return deploy.uploadFiles(indexFiles);
+    } else {
+      return readFile('dist/index.html')
+        .then(function(fileContent) {
+          ui.writeLine(chalk.blue('\nUploading `dist/index.html`...\n'));
+          return deploy.upload(fileContent);
+        });
+    }
   }
 });


### PR DESCRIPTION
Support the `indexFiles` option to support more than just `index.html` being uploaded. By setting the `indexFiles` attribute in the deployment config, the index-adapter's `uploadFiles` method is called instead of `upload`.